### PR TITLE
chore(variables): add validation for github_repositories

### DIFF
--- a/current.tf
+++ b/current.tf
@@ -1,14 +1,14 @@
 data "aws_partition" "current" {}
 
 locals {
-  repositories_branches = flatten([
+  repositories_branches = length(var.github_repositories) > 0 ? flatten([
     for repo in var.github_repositories : [
       for branch in repo.branches : {
         branch = branch
         name   = repo.name
       }
     ]
-  ])
+  ]) : []
 }
 
 data "aws_iam_policy_document" "assume_role" {
@@ -16,10 +16,13 @@ data "aws_iam_policy_document" "assume_role" {
     actions = ["sts:AssumeRoleWithWebIdentity"]
     effect  = "Allow"
 
-    condition {
-      test     = "ForAnyValue:StringLike"
-      values   = [for repo in local.repositories_branches : format("repo:%s/%s:%s", var.github_organisation, repo.name, repo.branch)]
-      variable = format("%s:sub", var.url)
+    dynamic "condition" {
+      for_each = length(local.repositories_branches) > 0 ? [1] : []
+      content {
+        test     = "ForAnyValue:StringLike"
+        values   = [for repo in local.repositories_branches : format("repo:%s/%s:%s", var.github_organisation, repo.name, repo.branch)]
+        variable = format("%s:sub", var.url)
+      }
     }
 
     principals {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,18 @@
 output "role_id" {
   description = "AWS role ID"
-  value       = aws_iam_role.role[0].id
+  value       = try(aws_iam_role.role[0].id, null)
   sensitive   = false
 }
 
 output "role_arn" {
   description = "AWS role ARN"
-  value       = aws_iam_role.role[0].arn
+  value       = try(aws_iam_role.role[0].arn, null)
+  sensitive   = false
+}
+
+output "role_name" {
+  description = "AWS role name"
+  value       = try(aws_iam_role.role[0].name, null)
   sensitive   = false
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -48,6 +48,11 @@ variable "github_repositories" {
     condition     = length(var.github_repositories) > 0
     error_message = "At least one GitHub repository must be specified."
   }
+
+  validation {
+    condition     = alltrue([for repo in var.github_repositories : length(repo.branches) > 0])
+    error_message = "Each GitHub repository must have at least one branch specified."
+  }
 }
 
 variable "iam_role_name" {

--- a/variables.tf
+++ b/variables.tf
@@ -43,6 +43,11 @@ variable "github_repositories" {
     name     = null
   }]
   description = "GitHub repository names and branches"
+
+  validation {
+    condition     = length(var.github_repositories) > 0
+    error_message = "At least one GitHub repository must be specified."
+  }
 }
 
 variable "iam_role_name" {


### PR DESCRIPTION
This pull request makes several improvements to the Terraform configuration, primarily to enforce input validation, handle empty repository lists gracefully, and enhance output robustness. The changes ensure that the module behaves predictably when no GitHub repositories are specified and improves the reliability of output variables.

Input validation and handling of empty repository lists:

* Added a validation block to the `github_repositories` variable in `variables.tf` to require at least one repository.
* Updated the `repositories_branches` local in `current.tf` to return an empty list if no repositories are provided, preventing errors from flattening an empty input.
* Modified the `condition` block in the IAM policy document in `current.tf` to be dynamic and only present when repositories are specified, avoiding unnecessary policy conditions.

Output improvements:

* Changed the output values for `role_id` and `role_arn` in `outputs.tf` to use `try()` for safer access, defaulting to `null` if the role is not present.
* Added a new output for `role_name` in `outputs.tf`, also using `try()` for robustness.

- **chore(tf/current): update local variable structure for repositories branches and enhance condition handling**
- **chore(outputs): add try function to handle potential null values for role outputs**
- **chore(variables): add validation for github_repositories to ensure at least one repository is specified**
